### PR TITLE
Fix listener leak in toast hook

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent duplicate listener registration in `useToast`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc867420832f9d32cd41d0bd05ca